### PR TITLE
Fix install on linux/arm64

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -10,6 +10,8 @@ set -euo pipefail
 arch=$(uname -m)
 if [[ ${arch} == x86_64 ]]; then
   arch=amd64
+elif [[ ${arch} == aarch64 ]]; then
+  arch=arm64
 fi
 
 platform="$(uname | tr A-Z a-z)"


### PR DESCRIPTION
This is required to be able to install nova if you are using linux and your architecture is arm64/aarch64 .