### PR TITLE
Support downloading nova v3.6.5 and up

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -32,7 +32,7 @@ install() {
   local bin_path="${install_path}/nova"
 
   local download_url
-  download_url="https://github.com/FairwindsOps/Nova/releases/download/${version}/Nova_${version}_${platform}_${arch}.tar.gz"
+  download_url="https://github.com/FairwindsOps/Nova/releases/download/v${version}/nova_${version}_${platform}_${arch}.tar.gz"
 
   mkdir -p "${install_path}"
 

--- a/bin/install
+++ b/bin/install
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+source "$(dirname "$0")/../lib/utils.sh"
+
 [[ -z ${ASDF_INSTALL_TYPE} ]] && echo "ASDF_INSTALL_TYPE is required" && exit 1
 [[ -z ${ASDF_INSTALL_VERSION} ]] && echo "ASDF_INSTALL_VERSION is required" && exit 1
 [[ -z ${ASDF_INSTALL_PATH} ]] && echo "ASDF_INSTALL_PATH is required" && exit 1
@@ -32,7 +34,12 @@ install() {
   local bin_path="${install_path}/nova"
 
   local download_url
-  download_url="https://github.com/FairwindsOps/Nova/releases/download/v${version}/nova_${version}_${platform}_${arch}.tar.gz"
+
+  if verlte "3.6.4" ${version}; then
+    download_url="https://github.com/FairwindsOps/Nova/releases/download/${version}/nova_${version}_${platform}_${arch}.tar.gz"
+  else
+    download_url="https://github.com/FairwindsOps/Nova/releases/download/v${version}/nova_${version}_${platform}_${arch}.tar.gz"
+  fi
 
   mkdir -p "${install_path}"
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,17 +1,13 @@
 #!/usr/bin/env bash
 
+source "$(dirname "$0")/../lib/utils.sh"
+
 releases_path=https://api.github.com/repos/FairwindsOps/Nova/releases
 cmd="curl -s"
 if [[ -n ${GITHUB_API_TOKEN} ]]; then
   cmd="$cmd -H 'Authorization: token ${GITHUB_API_TOKEN}'"
 fi
 cmd="${cmd} ${releases_path}"
-
-# stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
-function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
 
 # Fetch all tag names, except 'latest_release'.
 echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | grep -v latest_release | sed 's/tag_name\": \"//;s/v\(.*\)/\1/;s/\",//' | sort_versions)

--- a/bin/list-all
+++ b/bin/list-all
@@ -14,4 +14,4 @@ function sort_versions() {
 }
 
 # Fetch all tag names, except 'latest_release'.
-echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | grep -v latest_release | sed 's/tag_name\": \"//;s/\",//' | sort_versions)
+echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | grep -v latest_release | sed 's/tag_name\": \"//;s/v\(.*\)/\1/;s/\",//' | sort_versions)

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,0 +1,14 @@
+# stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
+function sort_versions() {
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
+
+function verlte() {
+  # Used in the official asdf-nodejs plugin.
+  #   https://github.com/asdf-vm/asdf-nodejs/blob/c0f37e2d14c630b04bace43c79bb361334723216/bin/install#L313-L316
+  # See also:
+  #   https://stackoverflow.com/questions/4023830/how-compare-two-strings-in-dot-separated-version-format-in-bash/4024263#4024263
+  # Note however, that we look at the _tail_ of the list rather than the head because our sort is backwards
+  [  "$1" = "$(echo -e "$1\n$2" | sort_versions | tail -n1)" ]
+}


### PR DESCRIPTION
- They seem to have moved from 'Nova' to 'nova' in asset name already some time. Github seems to forgive mispelling in the name and resolves 'Nova' as well, but the actual asset name is in lower case.
- From version 3.6.5 they changed the version name from X.Y.Z to vX.Y.Z and this actually breaks the install script.

Got this error:
```
  Downloading nova from https://github.com/FairwindsOps/Nova/releases/download/3.8.0/Nova_3.8.0_linux_amd64.tar.gz
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
  100     9  100     9    0     0     34      0 --:--:-- --:--:-- --:--:--    35

  gzip: stdin: not in gzip format
  tar: Child returned status 1
  tar: Error is not recoverable: exiting now
```

This PR fixes `download_url` only for newer (v3.6.5+) and up and breaks for lower versions. Ideally it could support both cases, but I would like to hear it back from you if it's important.